### PR TITLE
Added support for additional hash methods and future options

### DIFF
--- a/src/administration.js
+++ b/src/administration.js
@@ -2,13 +2,13 @@
 
 const util = require('./util')
 
-function administration(host, salt) {
+function administration(options) {
   function create(name, id, kwparams) {
     kwparams = { ...kwparams }
     kwparams.name = name
     kwparams.meetingID = id
 
-    return util.constructUrl(host, salt, 'create', kwparams)
+    return util.constructUrl(options, 'create', kwparams)
   }
   function join(fullName, meetingID, password, kwparams) {
     kwparams = { ...kwparams }
@@ -16,14 +16,14 @@ function administration(host, salt) {
     kwparams.meetingID = meetingID
     kwparams.password = password
 
-    return util.constructUrl(host, salt, 'join', kwparams)
+    return util.constructUrl(options, 'join', kwparams)
   }
   function end(meetingID, password) {
     let kwparams = {
       meetingID: meetingID,
       password: password,
     }
-    return util.constructUrl(host, salt, 'end', kwparams)
+    return util.constructUrl(options, 'end', kwparams)
   }
   return {
     create,

--- a/src/api.js
+++ b/src/api.js
@@ -2,13 +2,14 @@
 
 let { normalizeUrl } = require('./util')
 
-function api(host, salt) {
-  host = normalizeUrl(host)
+function api(host, salt, options = {}) {
+  options.host = normalizeUrl(host)
+  options.salt = salt
 
-  let administration = require('./administration')(host, salt)
-  let monitoring = require('./monitoring')(host, salt)
-  let recording = require('./recording')(host, salt)
-  let hooks = require('./hooks')(host, salt)
+  let administration = require('./administration')(options)
+  let monitoring = require('./monitoring')(options)
+  let recording = require('./recording')(options)
+  let hooks = require('./hooks')(options)
 
   return {
     administration,

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -2,22 +2,22 @@
 
 const util = require('./util')
 
-function hooks(host, salt) {
+function hooks(options) {
   function create(callbackURL, kwparams) {
     kwparams = { ...kwparams }
     kwparams.callbackURL = callbackURL
 
-    return util.constructUrl(host, salt, 'hooks/create', kwparams)
+    return util.constructUrl(options, 'hooks/create', kwparams)
   }
   function destroy(hookID, kwparams) {
     kwparams = { ...kwparams }
     kwparams.hookID = hookID
 
-    return util.constructUrl(host, salt, 'hooks/destroy', kwparams)
+    return util.constructUrl(options, 'hooks/destroy', kwparams)
   }
   function list(kwparams) {
     kwparams = { ...kwparams }
-    return util.constructUrl(host, salt, 'hooks/list', kwparams)
+    return util.constructUrl(options, 'hooks/list', kwparams)
   }
   return {
     create,

--- a/src/monitoring.js
+++ b/src/monitoring.js
@@ -2,25 +2,25 @@
 
 const util = require('./util')
 
-function monitoring(host, salt) {
+function monitoring(options) {
   function getMeetingInfo(meetingID) {
     let qparams = {
       meetingID: meetingID,
     }
 
-    return util.constructUrl(host, salt, 'getMeetingInfo', qparams)
+    return util.constructUrl(options, 'getMeetingInfo', qparams)
   }
   function isMeetingRunning(meetingID) {
     let qparams = {
       meetingID: meetingID,
     }
 
-    return util.constructUrl(host, salt, 'isMeetingRunning', qparams)
+    return util.constructUrl(options, 'isMeetingRunning', qparams)
   }
   function getMeetings() {
     let qparams = {}
 
-    return util.constructUrl(host, salt, 'getMeetings', qparams)
+    return util.constructUrl(options, 'getMeetings', qparams)
   }
   return {
     getMeetingInfo,

--- a/src/recording.js
+++ b/src/recording.js
@@ -2,11 +2,11 @@
 
 const util = require('./util')
 
-function recording(host, salt) {
+function recording(options) {
   function getRecordings(kwparams) {
     kwparams = { ...kwparams }
 
-    return util.constructUrl(host, salt, 'getRecordings', kwparams)
+    return util.constructUrl(options, 'getRecordings', kwparams)
   }
   function publishRecordings(recordID, publish) {
     let qparams = {
@@ -14,21 +14,21 @@ function recording(host, salt) {
       publish: publish,
     }
 
-    return util.constructUrl(host, salt, 'publishRecordings', qparams)
+    return util.constructUrl(options, 'publishRecordings', qparams)
   }
   function deleteRecordings(recordID) {
     let qparams = {
       recordID: recordID,
     }
 
-    return util.constructUrl(host, salt, 'deleteRecordings', qparams)
+    return util.constructUrl(options, 'deleteRecordings', qparams)
   }
   function updateRecordings(recordID, kwparams) {
     kwparams = { ...kwparams }
 
     kwparams.recordID = recordID
 
-    return util.constructUrl(host, salt, 'updateRecordings', kwparams)
+    return util.constructUrl(options, 'updateRecordings', kwparams)
   }
   return {
     getRecordings,

--- a/src/util.js
+++ b/src/util.js
@@ -5,15 +5,14 @@ const querystring = require('querystring')
 const crypto = require('hash.js')
 const parser = require('fast-xml-parser')
 
-function getChecksum(callName, queryParams, sharedSecret) {
-  return crypto
-    .sha1()
+function getChecksum(callName, queryParams, sharedSecret, hashMethod = 'sha1') {
+  return crypto[hashMethod]()
     .update(`${callName}${querystring.encode(queryParams)}${sharedSecret}`)
     .digest('hex')
 }
 
 function constructUrl(options, action, params) {
-  params.checksum = getChecksum(action, params, options.salt)
+  params.checksum = getChecksum(action, params, options.salt, options.hashMethod)
   return `${options.host}/api/${action}?${querystring.encode(params)}`
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -12,9 +12,9 @@ function getChecksum(callName, queryParams, sharedSecret) {
     .digest('hex')
 }
 
-function constructUrl(host, salt, action, params) {
-  params.checksum = getChecksum(action, params, salt)
-  return `${host}/api/${action}?${querystring.encode(params)}`
+function constructUrl(options, action, params) {
+  params.checksum = getChecksum(action, params, options.salt)
+  return `${options.host}/api/${action}?${querystring.encode(params)}`
 }
 
 function httpClient(url) {
@@ -44,7 +44,7 @@ function parseXml(xml) {
     let meetings = json.meetings ? json.meetings.meeting : []
     meetings = Array.isArray(meetings) ? meetings : [meetings]
     json.meetings = meetings
-  }  
+  }
   if (json.recordings) {
     let recordings = json.recordings ? json.recordings.recording : []
     recordings = Array.isArray(recordings) ? recordings : [recordings]


### PR DESCRIPTION
This pull request adds support for selecting the hash method used while communicating with BBB. When initializing the library you can now pass the third parameter with additional options, using the `hashMethod` option to select the method. Accepted hash methods should be any of the available methods on the `hash.js` library, although I'm not sure BBB supports anything other than sha1 and sha256.

```js
const api = bbb.api(url, secret, {
  hashMethod: 'sha256'
}
```

The hash method defaults to sha1 to avoid creating issues with unsupported BBB backends, although with a major semver bump this default could be changed.

To facilitate this change, I added the new `options` parameter for use when initializing the library, these options are consolidated into a single object that is passed around instead of the previous two `host` and `salt` strings. This allows future expansion with more options as required without affecting the existing initialization syntax.

This may help with issue #6 too.